### PR TITLE
Clear extension list to avoid reporting stale data.

### DIFF
--- a/api-list.sh
+++ b/api-list.sh
@@ -174,6 +174,7 @@ getVersion()
 {
   #VERS=$(otc.sh custom GET $rept 2>/dev/null)
 
+  unset EXT
   VERS=$(curl -m 6 -sS -X GET $resolv -H "Content-Type: application/json" -H "Accept: application/json" \
               -H "X-Auth-Token: $id" -H "X-Language: en-us" "$rept" 2>/dev/null)
   RC=$?


### PR DESCRIPTION
When version querying fails, we would not re-retrieve the extension
list and rather report the one from the previous service. Fixed.

Signed-off-by: Kurt Garloff <kurt@garloff.de>